### PR TITLE
Allow create_table to be called without a block

### DIFF
--- a/lib/migration_comments/active_record/connection_adapters/mysql_adapter.rb
+++ b/lib/migration_comments/active_record/connection_adapters/mysql_adapter.rb
@@ -43,7 +43,7 @@ module MigrationComments::ActiveRecord::ConnectionAdapters
         local_table_definition = td
         local_table_definition.base = self
         local_table_definition.comment options[:comment] if options.has_key?(:comment)
-        block.call(td)
+        block.call(td) if block
       end
       comments = local_table_definition.collect_comments(table_name)
       comments.each do |comment_definition|

--- a/lib/migration_comments/active_record/connection_adapters/postgresql_adapter.rb
+++ b/lib/migration_comments/active_record/connection_adapters/postgresql_adapter.rb
@@ -39,7 +39,7 @@ module MigrationComments::ActiveRecord::ConnectionAdapters
         local_table_definition = td
         local_table_definition.base = self
         local_table_definition.comment options[:comment] if options.has_key?(:comment)
-        block.call(td)
+        block.call(td) if block
       end
       comments = local_table_definition.collect_comments(table_name)
       comments.each do |comment_definition|

--- a/test/add_comments_test.rb
+++ b/test/add_comments_test.rb
@@ -26,6 +26,12 @@ class AddCommentsTest < Test::Unit::TestCase
     assert_nil result_field2
   end
 
+  def test_creating_a_table_with_table_comments_and_no_block
+    ActiveRecord::Schema.define do
+      create_table :sample3, :temporary => true, :comment => "a table comment"
+    end
+  end
+
   def test_creating_a_table_with_table_and_column_comments
     table_comment = "a table comment"
     column_comment = "a column comment"


### PR DESCRIPTION
We had a few more edge cases in our project that broke some things, so I've added a test to reproduce the problem and fixed it in the mysql and postgres adapters.  AR's create_table _can_ be called without a block and we're doing it in a few places.  :-/
