### PR TITLE
Comments in schema.rb should be escaped

### DIFF
--- a/lib/migration_comments/schema_formatter.rb
+++ b/lib/migration_comments/schema_formatter.rb
@@ -13,7 +13,7 @@ module MigrationComments
     end
 
     def render_value(value)
-      value.is_a?(String) ? "\"#{value}\"" : value
+      value.is_a?(String) ? %Q[#{value}].inspect : value
     end
   end
 end


### PR DESCRIPTION
Hi,
excuse me, I just saw your answer.
I'm proud to improve this wonderful gem.
