### PR TITLE
support after Rails 4.2.0.rc1

### DIFF
--- a/lib/migration_comments/active_record/connection_adapters/table.rb
+++ b/lib/migration_comments/active_record/connection_adapters/table.rb
@@ -1,11 +1,11 @@
 module MigrationComments::ActiveRecord::ConnectionAdapters
   module Table
     def change_comment(column_name, comment_text)
-      @base.set_column_comment(@table_name, column_name, comment_text)
+      @base.set_column_comment(@table_name || name, column_name, comment_text)
     end
 
     def change_table_comment(comment_text)
-      @base.set_table_comment(@table_name, comment_text)
+      @base.set_table_comment(@table_name || name, comment_text)
     end
     alias comment :change_table_comment
   end


### PR DESCRIPTION
Renamed instance variable `table_name` to `name` after Rails version 4.2.0.rc1, and Table#name accessor is added.
So enable both of Rails version under 4.2.0.beta4 and over 4.2.0.rc1.

SEE ALSO: https://github.com/rails/rails/commit/76e7305ea16b41a3674f4213ab7faa8c65196d75
