### PR TITLE
Require active_support for `descendants` method

### DIFF
--- a/lib/migration_comments.rb
+++ b/lib/migration_comments.rb
@@ -14,6 +14,8 @@ require 'migration_comments/active_record/connection_adapters/mysql2_adapter'
 require 'migration_comments/active_record/connection_adapters/postgresql_adapter'
 require 'migration_comments/active_record/connection_adapters/sqlite3_adapter'
 
+require 'active_support/core_ext/class/subclasses'
+
 module MigrationComments
   def self.setup
 


### PR DESCRIPTION
Hi,

I noticed when using this gem with Rails 5. `descendants` method is defined by active_support. And when using, we have to require that specifically.

backtrace:

```
$ bin/rails db:migrate
rails aborted!
Bundler::GemRequireError: There was an error while trying to load the gem 'migration_comments'.
Gem Load Error is: undefined method `descendants' for ActiveRecord::SchemaDumper:Class
Backtrace for gem load error is:
/src/github.com/xxxx/.bundle/ruby/2.3.0/gems/migration_comments-0.4.1/lib/migration_comments.rb:26:in `block in setup'
/src/github.com/xxxx/.bundle/ruby/2.3.0/gems/migration_comments-0.4.1/lib/migration_comments.rb:23:in `each'
/src/github.com/xxxx/.bundle/ruby/2.3.0/gems/migration_comments-0.4.1/lib/migration_comments.rb:23:in `setup'
/src/github.com/xxxx/.bundle/ruby/2.3.0/gems/migration_comments-0.4.1/lib/migration_comments.rb:59:in `<top (required)>'
/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/bundler-1.12.5/lib/bundler/runtime.rb:86:in `require'
/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/bundler-1.12.5/lib/bundler/runtime.rb:86:in `block (2 levels) in require'
/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/bundler-1.12.5/lib/bundler/runtime.rb:81:in `each'
/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/bundler-1.12.5/lib/bundler/runtime.rb:81:in `block in require'
/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/bundler-1.12.5/lib/bundler/runtime.rb:70:in `each'
/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/bundler-1.12.5/lib/bundler/runtime.rb:70:in `require'
/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/bundler-1.12.5/lib/bundler.rb:102:in `require'
/src/github.com/xxxx/config/application.rb:14:in `<top (required)>'
/src/github.com/xxxx/Rakefile:1:in `require_relative'
/src/github.com/xxxx/Rakefile:1:in `<top (required)>'
/src/github.com/xxxx/.bundle/ruby/2.3.0/gems/rake-11.2.2/lib/rake/rake_module.rb:28:in `load'
/src/github.com/xxxx/.bundle/ruby/2.3.0/gems/rake-11.2.2/lib/rake/rake_module.rb:28:in `load_rakefile'
/src/github.com/xxxx/.bundle/ruby/2.3.0/gems/rake-11.2.2/lib/rake/application.rb:686:in `raw_load_rakefile'
/src/github.com/xxxx/.bundle/ruby/2.3.0/gems/rake-11.2.2/lib/rake/application.rb:96:in `block in load_rakefile'
/src/github.com/xxxx/.bundle/ruby/2.3.0/gems/rake-11.2.2/lib/rake/application.rb:178:in `standard_exception_handling'
/src/github.com/xxxx/.bundle/ruby/2.3.0/gems/rake-11.2.2/lib/rake/application.rb:95:in `load_rakefile'
/src/github.com/xxxx/.bundle/ruby/2.3.0/gems/railties-5.0.0/lib/rails/commands/rake_proxy.rb:12:in `block in run_rake_task'
/src/github.com/xxxx/.bundle/ruby/2.3.0/gems/rake-11.2.2/lib/rake/application.rb:178:in `standard_exception_handling'
/src/github.com/xxxx/.bundle/ruby/2.3.0/gems/railties-5.0.0/lib/rails/commands/rake_proxy.rb:10:in `run_rake_task'
/src/github.com/xxxx/.bundle/ruby/2.3.0/gems/railties-5.0.0/lib/rails/commands/commands_tasks.rb:51:in `run_command!'
/src/github.com/xxxx/.bundle/ruby/2.3.0/gems/railties-5.0.0/lib/rails/commands.rb:18:in `<top (required)>'
bin/rails:9:in `require'
```
