### PR TITLE
Fix multiple lines bugs

### DIFF
--- a/lib/migration_comments/annotate_models.rb
+++ b/lib/migration_comments/annotate_models.rb
@@ -25,10 +25,25 @@ module MigrationComments
         len = lines.select{|l| l =~ column_regex}.map{|l| l.length}.max
         lines.each do |line|
           if line =~ /# Table name: |# table \+\w+\+ /
-            line << " # #{table_comment}" if table_comment
+            table_comment_lines = table_comment.chomp.split($/)
+            space_size = line.length - 1
+            first_comment = table_comment_lines.shift
+            line << " # #{first_comment}" if table_comment
+
+            table_comment_lines.each do |comment_line|
+              line << $/ << "#" << " " * space_size << " # #{comment_line}"
+            end
           elsif line =~ column_regex
             comment = column_comments[$1.to_sym]
-            line << " " * (len - line.length) << " # #{comment}" if comment
+            next unless comment
+
+            comment_lines = comment.chomp.split($/)
+            first_comment = comment_lines.shift
+            line << " " * (len - line.length) << " # #{first_comment}"
+
+            comment_lines.each do |comment_line|
+              line << $/ << "#" << " " * (len - 1) << " # #{comment_line}"
+            end
           end
         end
         lines.join($/) + $/

--- a/test/annotate_models_test.rb
+++ b/test/annotate_models_test.rb
@@ -13,27 +13,29 @@ class AnnotateModelsTest < Minitest::Test
 
   def test_annotate_includes_comments
     ActiveRecord::Schema.define do
-      set_table_comment :sample, "a table comment"
+      set_table_comment :sample, "a table comment\n(multiple lines)\n"
       set_column_comment :sample, :field1, "a \"comment\" \\ that ' needs; escaping''"
-      add_column :sample, :field3, :string, :null => false, :default => '', :comment => "third column comment"
+      add_column :sample, :field3, :string, :null => false, :default => '', :comment => "third column comment\n(multiple lines)\n"
     end
 
     result = AnnotateModels.get_schema_info(Sample, TEST_PREFIX)
 
     string_token = ENV['DB'] == 'mysql' ? ':string(255)' : ':string     '
+    token_spaces = " " * string_token.length
 
     expected = <<EOS
 # #{TEST_PREFIX}
 #
 # Table name: sample # a table comment
+#                    # (multiple lines)
 #
 #  id     :integer          not null, primary key
 #  field1 #{string_token}                            # a "comment" \\ that ' needs; escaping''
 #  field2 :integer
 #  field3 #{string_token}      default(""), not null # third column comment
+#         #{token_spaces}                            # (multiple lines)
 #
 EOS
     assert_equal expected, result
   end
 end
-


### PR DESCRIPTION
I use DB table and column comments by multiple lines.
But migration_comments annotation feature brokes annotations when there are multiple lines.

e.x.)

DB a table `users` comment:
```
this
table for
users
```

migration_comments annotation:
```
# Table name: users # this
table for
users
#
#
```
↑ it's broken as comments.

I want the following annotation.
```
# Table name: users # this
#                   # table for
#                   # users
#
#
```
